### PR TITLE
[BUGFIX] prevent exception

### DIFF
--- a/Classes/DemandProvider/RequestDemandProvider.php
+++ b/Classes/DemandProvider/RequestDemandProvider.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace Pixelant\Demander\DemandProvider;
 
 use Pixelant\Demander\Service\RequestSingleton;
+use Psr\Http\Message\ServerRequestInterface;
 
 class RequestDemandProvider implements DemandProviderInterface
 {
     public function getDemand(): array
     {
-        $request = RequestSingleton::getInstance()->getRequest();
-        $demands = $request->getParsedBody()['d'];
+        $request = RequestSingleton::getInstance()->getRequest() ?? null;
+        if ($request instanceof ServerRequestInterface) {
+            $demands = $request->getParsedBody()['d'];
+        }
 
         if ($demands) {
             return $demands;

--- a/Classes/Service/RequestSingleton.php
+++ b/Classes/Service/RequestSingleton.php
@@ -32,7 +32,7 @@ class RequestSingleton implements \TYPO3\CMS\Core\SingletonInterface
     {
     }
 
-    public function getRequest(): ServerRequestInterface
+    public function getRequest(): ?ServerRequestInterface
     {
         return $this->request;
     }


### PR DESCRIPTION
Return value of Pixelant\Demander\Service\RequestSingleton::getRequest() must implement interface Psr\Http\Message\ServerRequestInterface, null returned